### PR TITLE
Accept POST requests for webhooks

### DIFF
--- a/src/KirbyGit.php
+++ b/src/KirbyGit.php
@@ -22,6 +22,7 @@ class KirbyGit
 
         $route = [];
         $route['pattern'] = 'gcapc/(:any)';
+        $route['method'] = 'GET|POST';
         $route['action'] = function($gitCommand) use ($gitHelper) {
             switch ($gitCommand) {
                 case "push":


### PR DESCRIPTION
GitHub only does POST request for its webhooks, so this is necessary to integrate with GitHub.

Without this change, any github webhook delivery fails with a 404. Afterwards, it succeeds