### PR TITLE
Fix composer.json to install in Kirby plugins folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,16 @@
   "license": "MIT",
   "require": {
     "pascalmh/git.php": "^1.0",
-    "php": ">=7.1.0",
-    "getkirby/cms": "^3.0.0"
+    "getkirby/composer-installer": "^1.1"
   },
   "autoload": {
     "files": ["config.php"],
     "psr-4": {
       "Blanko\\Kirby\\GCAPC\\": "src/"
     }
+  },
+  "extra": {
+    "installer-name": "git-content"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,5 @@
   },
   "extra": {
     "installer-name": "git-content"
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/thathoff/kirby-git-content"
-    }
-  ]
+  }
 }

--- a/index.php
+++ b/index.php
@@ -2,4 +2,4 @@
 
 // Support manual installation inside kirby’s plugin directory
 
-require_once __DIR__ . '/vendor/autoload.php';
+@include_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Installing this package via composer does not correctly place the package in the Kirby plugins directory. Per the https://getkirby.com/docs/guide/plugins/plugin-setup-basic#the-composer-json tutorial, a Kirby plugin should require `getkirby/composer-installer` in order to ensure that downstream users can download the package to the correct spot in their `site/plugins` directory.

I also removed the repositories property, as I believe it was used incorrectly to point to this GitHub repo (you could include a [`support` property](https://getcomposer.org/doc/04-schema.md#support) with a `source` key if you wanted to link to this repo).

Finally, `index.php` needs to `@include_once` instead of require the `vender/autoload.php` file since it won't be present if using `getkirby/composer-installer`. See https://getkirby.com/docs/guide/plugins/plugin-setup-composer#support-for-plugin-installation-without-composer for more.