### PR TITLE
Use email as author name if user name is not set

### DIFF
--- a/src/KirbyGitHelper.php
+++ b/src/KirbyGitHelper.php
@@ -117,7 +117,7 @@ class KirbyGitHelper
 
                 $author = null;
                 if ($user) {
-                    $author = $user->name() . " <" . $user->email() . ">";
+                    $author = $user->name()->or($user->email()) . " <" . $user->email() . ">";
                 }
 
                 $this->commit($this->commitMessage($action, $item, $url), $author);


### PR DESCRIPTION
Kirby does not require a user to set a name and uses the email as a fallback itself, I think the commit author name should behave the same way. 

Fixes #57