### PR TITLE
Adapt to Coyl\Git method names

### DIFF
--- a/src/KirbyGitHelper.php
+++ b/src/KirbyGitHelper.php
@@ -44,16 +44,16 @@ class KirbyGitHelper
         $this->windowsMode = option('thathoff.git-content.windowsMode', false);
 
         if ($this->windowsMode) {
-            Git::windows_mode();
+            Git::windowsMode();
         }
         if ($this->gitBin) {
-            Git::set_bin($this->gitBin);
+            Git::setBin($this->gitBin);
         }
 
         $this->repo = Git::open($this->repoPath);
 
         if (!$this->repo->test_git()) {
-            throw new Exception('git could not be found or is not working properly. ' . Git::get_bin());
+            throw new Exception('git could not be found or is not working properly. ' . Git::getBin());
         }
     }
 


### PR DESCRIPTION
setting the git binary does not work because of the method naming changes in this commit: https://github.com/coyl/git/commit/c8548afd9d948c214a39e752b2710ab64a63ce87