### PR TITLE
Add secret parameter to the webhooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ return [
       'commit' => true,
     ],
   ],
-]
+];
 ```
 
 #### Configuration Options
@@ -75,6 +75,8 @@ return [
 - `push` (Boolean): Push your changes to remote? (default: `false`)
 - `commitMessageTemplate` (String): Configure the template for the commit message (default: `:action:(:item:): :url:`)
 - `cronHooksEnabled` (Boolean): Whether `/git-content/push` and `/git-content/pull` endpoints are enabled or not. (default: `true`)
+- `cronHooksSecret` (String): When set, this secret must be sent with the cronHooks as a get parameter.  Note: If you set
+  a secret, only the GET method will work on the webhooks.   `/git-content/(pull|push)?secret=S0up3rS3c3t`
 - `displayErrors` (Boolean): Display git errors when saving pages (default: `false`)
 - `gitBin` (String): Path to the `git` binary, [See Git.php](http://kbjr.github.io/Git.php/) `Git::set_bin(string $path)`
 - `windowsMode` (Boolean): [See Git.php](http://kbjr.github.io/Git.php/) `Git::windows_mode()` (default: `false`)
@@ -84,8 +86,6 @@ return [
 By default the commit message is composed from the template `:action:(:item:): :url:`. So for example a change to
 the page `example` will be committed with the message `update(page): example`. If you would like to change that
 message you can use the `thathoff.git-content.commitMessageTemplate` option to overwrite the template.
-
-#### Configuration Options
 
 ## Git LFS
 Your repository might increase over time, by adding Images, Audio, Video, Binaries, etc.

--- a/index.php
+++ b/index.php
@@ -15,6 +15,7 @@ Kirby::plugin('thathoff/git-content', [
         'push' => null,
         'commit' => null,
         'cronHooksEnabled' => null,
+        'cronHooksSecret' => null,
         'commitMessage' => ':action:(:item:): :url:',
         'windowsMode' => null,
         'gitBin' => null,

--- a/src/KirbyGit.php
+++ b/src/KirbyGit.php
@@ -24,6 +24,17 @@ class KirbyGit
         $route['pattern'] = 'git-content/(:any)';
         $route['method'] = 'GET|POST';
         $route['action'] = function($gitCommand) use ($gitHelper) {
+            // check to see if a secret is set, and if it is, verify it
+            $secret = option('thathoff.git-content.cronHooksSecret', '');
+            if ($secret !== '') {
+                $passedSecret = kirby()->request()->get('secret', '');
+                if ($passedSecret !== $secret) {
+                    return [
+                        'status' => 'forbidden',
+                        'message' => 'Invalid secret passed',
+                    ];
+                }
+            }
             switch ($gitCommand) {
                 case "push":
                     try {


### PR DESCRIPTION
Hi, I've added the ability to add a secret "token" to the webhooks so that they can't just be called by anyone on the Internet.

This addresses #11, although not in the way he requested.  I think adding a token like this is sufficient though and much easier to use in a webhook.