### PR TITLE
fix: resolve the deprecated warning for KirbyGitHelper

### DIFF
--- a/src/KirbyGitHelper.php
+++ b/src/KirbyGitHelper.php
@@ -9,7 +9,6 @@ use CzProject\GitPhp\GitRepository;
 use DateTime;
 use Exception;
 
-#[\AllowDynamicProperties]
 class KirbyGitHelper
 {
     private $kirby;
@@ -20,6 +19,7 @@ class KirbyGitHelper
     private $pushOnChange;
     private $commitOnChange;
     private $gitBin;
+    private $git;
 
     public function __construct($repoPath = false)
     {
@@ -47,8 +47,8 @@ class KirbyGitHelper
         }
         // force English locale for predictable command outputs
         $runner = new CliRunner('LC_ALL=C ' . $this->gitBin);
-        $this->git = new Git($runner);
-        $this->repo = $this->git->open($this->repoPath);
+        $git = new Git($runner);
+        $this->repo = $git->open($this->repoPath);
     }
 
     public function log(int $limit = 10)

--- a/src/KirbyGitHelper.php
+++ b/src/KirbyGitHelper.php
@@ -47,8 +47,8 @@ class KirbyGitHelper
         }
         // force English locale for predictable command outputs
         $runner = new CliRunner('LC_ALL=C ' . $this->gitBin);
-        $git = new Git($runner);
-        $this->repo = $git->open($this->repoPath);
+        $this->git = new Git($runner);
+        $this->repo = $this->git->open($this->repoPath);
     }
 
     public function log(int $limit = 10)

--- a/src/KirbyGitHelper.php
+++ b/src/KirbyGitHelper.php
@@ -9,6 +9,7 @@ use CzProject\GitPhp\GitRepository;
 use DateTime;
 use Exception;
 
+#[\AllowDynamicProperties]
 class KirbyGitHelper
 {
     private $kirby;


### PR DESCRIPTION
## Description

The PR addresses the `'KirbyGitHelper::$git is deprecated' error` as expressed in the #98